### PR TITLE
RHDHPAI-1028: Add edit RoleBinding to user namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	projectclient "github.com/openshift/client-go/project/clientset/versioned"
 	userclient "github.com/openshift/client-go/user/clientset/versioned"
 	"github.com/redhat-ai-dev/rosa-namespace-provisioner/pkg/controller"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
@@ -48,8 +49,14 @@ func main() {
 		klog.Fatalf("Failed to create OpenShift project client: %v", err)
 	}
 
+	// Create the RBAC client
+	rbacClient, err := rbacv1client.NewForConfig(config)
+	if err != nil {
+		klog.Fatalf("Failed to create RBAC client: %v", err)
+	}
+
 	// Create and start the controller
-	ctrl := controller.NewController(userClient, projectClient)
+	ctrl := controller.NewController(userClient, projectClient, rbacClient)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -138,7 +138,7 @@ func (c *Controller) handleGroup(oldGroup, newGroup *userv1.Group) {
 			if err != nil {
 				if errors.IsNotFound(err) {
 					klog.Infof("Project %s not found for user %s", user, user)
-					// TODO: Create project logic could go here
+					// Create project
 					project := &projectv1.Project{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: user,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,11 +17,14 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// default value of the target group name
+const defaultTargetGroupName = "redhat-ai-dev-users"
+
 // GetTargetGroupName returns the target group name from environment variable or default
 func GetTargetGroupName() string {
 	groupName := os.Getenv("TARGET_GROUP_NAME")
 	if groupName == "" {
-		return "redhat-ai-dev-edit-users" // default value
+		return defaultTargetGroupName // default value
 	}
 	return groupName
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -9,9 +10,12 @@ import (
 	userv1 "github.com/openshift/api/user/v1"
 	projectfake "github.com/openshift/client-go/project/clientset/versioned/fake"
 	userfake "github.com/openshift/client-go/user/clientset/versioned/fake"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestGetTargetGroupName(t *testing.T) {
@@ -195,8 +199,14 @@ func TestController_handleGroup(t *testing.T) {
 
 			// Create fake clients
 			var projectObjects []runtime.Object
+			var namespaceObjects []runtime.Object
 			for _, projectName := range tt.existingProjects {
 				projectObjects = append(projectObjects, &projectv1.Project{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: projectName,
+					},
+				})
+				namespaceObjects = append(namespaceObjects, &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: projectName,
 					},
@@ -205,11 +215,13 @@ func TestController_handleGroup(t *testing.T) {
 
 			userClient := userfake.NewSimpleClientset()
 			projectClient := projectfake.NewSimpleClientset(projectObjects...)
+			rbacClient := fake.NewSimpleClientset(namespaceObjects...).RbacV1()
 
 			// Create controller
 			controller := &Controller{
 				userClient:    userClient,
 				projectClient: projectClient,
+				rbacClient:    rbacClient,
 			}
 
 			// Call handleGroup
@@ -269,6 +281,226 @@ func TestController_handleGroup(t *testing.T) {
 	}
 }
 
+func TestController_createRoleBinding(t *testing.T) {
+	tests := []struct {
+		name  string
+		users []struct {
+			user    string
+			project string
+		}
+		existingRoleBindings []struct {
+			name    string
+			project string
+		}
+		shouldError bool
+	}{
+		{
+			name: "Create RoleBindings for target users their projects",
+			users: []struct {
+				user    string
+				project string
+			}{
+				{
+					user:    "bob",
+					project: "bob-dev",
+				},
+				{
+					user:    "john",
+					project: "ai-dev",
+				},
+				{
+					user:    "sarah",
+					project: "workspace",
+				},
+			},
+		},
+		{
+			name: "Create RoleBindings for target users their projects along existing RoleBindings",
+			users: []struct {
+				user    string
+				project string
+			}{
+				{
+					user:    "bob",
+					project: "bob-dev",
+				},
+				{
+					user:    "john",
+					project: "ai-dev",
+				},
+				{
+					user:    "sarah",
+					project: "workspace",
+				},
+			},
+			existingRoleBindings: []struct {
+				name    string
+				project string
+			}{
+				{
+					name:    "ai-dev-edit",
+					project: "ai-dev-testing",
+				},
+				{
+					name:    "project-edit",
+					project: "dev",
+				},
+			},
+		},
+		{
+			name: "Attempt to create an existing RoleBinding",
+			users: []struct {
+				user    string
+				project string
+			}{
+				{
+					user:    "john",
+					project: "ai-dev",
+				},
+			},
+			existingRoleBindings: []struct {
+				name    string
+				project string
+			}{
+				{
+					name:    "ai-dev-edit",
+					project: "ai-dev",
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "Attempt to create two RoleBindings for the same project",
+			users: []struct {
+				user    string
+				project string
+			}{
+				{
+					user:    "john",
+					project: "ai-dev",
+				},
+				{
+					user:    "mike",
+					project: "ai-dev",
+				},
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Create addedUsers
+			addedUsers := make(map[string]bool)
+			for _, userinfo := range tt.users {
+				addedUsers[userinfo.user] = false
+			}
+
+			// Create addedProjects
+			addedProjects := make(map[string]bool)
+			for _, userinfo := range tt.users {
+				addedProjects[userinfo.project] = false
+			}
+
+			// Create addedRoleBindings
+			addedRoleBindings := make(map[string]bool)
+			for _, roleBinding := range tt.existingRoleBindings {
+				addedRoleBindings[roleBinding.name] = false
+			}
+
+			// Create fake user objects and their project/namespace objects
+			var userObjects []runtime.Object
+			var projectObjects []runtime.Object
+			var kubernetesObjects []runtime.Object
+			for _, userinfo := range tt.users {
+				if !addedUsers[userinfo.user] {
+					userObjects = append(userObjects, &userv1.User{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: userinfo.user,
+						},
+					})
+					addedUsers[userinfo.user] = true
+				}
+				if !addedProjects[userinfo.project] {
+					projectObjects = append(projectObjects, &projectv1.Project{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: userinfo.project,
+						},
+					})
+					kubernetesObjects = append(kubernetesObjects, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: userinfo.project,
+						},
+					})
+					addedProjects[userinfo.project] = true
+				}
+			}
+
+			// Create existing RoleBindings objects and their project/namespace objects
+			for _, roleBinding := range tt.existingRoleBindings {
+				if !addedRoleBindings[roleBinding.name] {
+					kubernetesObjects = append(kubernetesObjects, &rbacv1.RoleBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      roleBinding.name,
+							Namespace: roleBinding.project,
+						},
+					})
+					addedRoleBindings[roleBinding.name] = true
+				}
+				if !addedProjects[roleBinding.project] {
+					projectObjects = append(projectObjects, &projectv1.Project{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: roleBinding.project,
+						},
+					})
+					kubernetesObjects = append(kubernetesObjects, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: roleBinding.project,
+						},
+					})
+					addedProjects[roleBinding.project] = true
+				}
+			}
+
+			// Create fake clients
+			userClient := userfake.NewSimpleClientset(userObjects...)
+			projectClient := projectfake.NewSimpleClientset(projectObjects...)
+			rbacClient := fake.NewSimpleClientset(kubernetesObjects...).RbacV1()
+
+			// Create controller
+			controller := &Controller{
+				userClient:    userClient,
+				projectClient: projectClient,
+				rbacClient:    rbacClient,
+			}
+
+			errorCount := 0
+			for _, userinfo := range tt.users {
+				expectedRoleBindingName := fmt.Sprintf("%s-edit", userinfo.project)
+				err := controller.createRoleBinding(userinfo.user, userinfo.project)
+				if !tt.shouldError && err != nil {
+					t.Errorf("Expected RoleBinding %s to be created, but got error: %v", expectedRoleBindingName, err)
+					continue
+				} else if tt.shouldError && err != nil {
+					errorCount += 1
+					continue
+				}
+
+				_, err = controller.rbacClient.RoleBindings(userinfo.project).Get(ctx, expectedRoleBindingName, metav1.GetOptions{})
+				if err != nil {
+					t.Errorf("Expected RoleBinding %s to be found, but got error: %v", expectedRoleBindingName, err)
+				}
+			}
+
+			if tt.shouldError && errorCount == 0 {
+				t.Errorf("Expected case '%s' to receive error(s)", tt.name)
+			}
+		})
+	}
+}
+
 func TestController_handleGroupErrorHandling(t *testing.T) {
 	t.Run("should continue processing when project creation fails for one user", func(t *testing.T) {
 		ctx := context.Background()
@@ -279,13 +511,16 @@ func TestController_handleGroupErrorHandling(t *testing.T) {
 				Name: "alice",
 			},
 		}
+		existingNamespace := &corev1.Namespace{ObjectMeta: existingProject.ObjectMeta}
 
 		userClient := userfake.NewSimpleClientset()
 		projectClient := projectfake.NewSimpleClientset(existingProject)
+		rbacClient := fake.NewSimpleClientset(existingNamespace).RbacV1()
 
 		controller := &Controller{
 			userClient:    userClient,
 			projectClient: projectClient,
+			rbacClient:    rbacClient,
 		}
 
 		// Create group with users where one will conflict
@@ -328,8 +563,9 @@ func TestNewController(t *testing.T) {
 
 	userClient := userfake.NewSimpleClientset()
 	projectClient := projectfake.NewSimpleClientset()
+	rbacClient := fake.NewSimpleClientset().RbacV1()
 
-	controller := NewController(userClient, projectClient)
+	controller := NewController(userClient, projectClient, rbacClient)
 
 	if controller == nil {
 		t.Fatal("Expected controller to be created, but got nil")
@@ -341,6 +577,10 @@ func TestNewController(t *testing.T) {
 
 	if controller.projectClient != projectClient {
 		t.Error("Expected projectClient to be set correctly")
+	}
+
+	if controller.rbacClient != rbacClient {
+		t.Error("Expected rbacClient to be set correctly")
 	}
 
 	if controller.informer == nil {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -28,7 +28,7 @@ func TestGetTargetGroupName(t *testing.T) {
 		{
 			name:     "environment variable empty",
 			envValue: "",
-			want:     "redhat-ai-dev-edit-users",
+			want:     defaultTargetGroupName,
 		},
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -148,7 +148,6 @@ func TestController_createRoleBinding(t *testing.T) {
 					project: "ai-dev",
 				},
 			},
-			shouldError: true,
 		},
 		{
 			name: "Attempt to create two RoleBindings for the same project",
@@ -302,13 +301,11 @@ func TestController_createUserProject(t *testing.T) {
 			name:             "Attempt to create an existing project",
 			users:            []string{"bob"},
 			existingProjects: []string{"bob"},
-			shouldError:      true,
 		},
 		{
 			name:             "Attempt to create existing projects",
 			users:            []string{"bob", "john"},
 			existingProjects: []string{"bob", "john"},
-			shouldError:      true,
 		},
 	}
 
@@ -374,7 +371,6 @@ func TestController_createUserProject(t *testing.T) {
 
 			errorCount := 0
 			for _, user := range tt.users {
-				expectedRoleBindingName := fmt.Sprintf("%s-edit", user)
 				err := controller.createUserProject(user)
 				if !tt.shouldError && err != nil {
 					t.Errorf("Expected project %s to be created, but got error: %v", user, err)
@@ -387,11 +383,6 @@ func TestController_createUserProject(t *testing.T) {
 				_, err = controller.projectClient.ProjectV1().Projects().Get(ctx, user, metav1.GetOptions{})
 				if err != nil {
 					t.Errorf("Expected project %s to be found, but got error: %v", user, err)
-				}
-
-				_, err = controller.rbacClient.RoleBindings(user).Get(ctx, expectedRoleBindingName, metav1.GetOptions{})
-				if err != nil {
-					t.Errorf("Expected RoleBinding %s to be found, but got error: %v", expectedRoleBindingName, err)
 				}
 			}
 


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/RHDHPAI-1028

## Add create user project function

Adds a function that creates a user project to replace existing code block under `handleGroup` that does the same.

## Add create RoleBinding function

Adds a function that creates a RoleBinding within a given project to the system `edit` ClusterRole and the given user.

## Use create RoleBinding function with project creation

Uses create RoleBinding function to create the edit RoleBinding for the user of the user provisioned project.