### PR TITLE
Add needed permissions to access RoleBindings via the provisioner SA

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -9,6 +9,9 @@ rules:
 - apiGroups: ["project.openshift.io"]
   resources: ["projects"]
   verbs: ["get", "list", "create", "delete"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["rolebindings"]
+  verbs: ["get", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/RHDHPAI-1028

## Add RBAC rule and permissions for `RoleBinding`

Add needed permissions to the RBAC spec of the provisioner so that access RoleBindings via the provisioner ServiceAccount is given.


